### PR TITLE
Switch to Native Open Graph implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,7 +261,7 @@ if (require.main === module) {
 		scrape = exports;
 
 	console.log('Parser running on test file');
-	$ = cheerio.load(fs.readFileSync('./test_files/turtles.html'));
+	$ = cheerio.load(fs.readFileSync('./test_files/turtle_movie.html'));
 	exports.parseAll($, function(err, results){
 		console.log(JSON.stringify(results));
 	});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
 		"async": "0.9.0",
 		"cheerio" : "0.18.0",
 		"microdata-node" : "0.1.2",
-		"open-graph" : "git://github.com/mvolz/node-open-graph.git",
 		"request" : "2.49.0"
 	},
 	"scripts": {

--- a/test_files/turtle_article.html
+++ b/test_files/turtle_article.html
@@ -9,6 +9,7 @@
 <meta name="author" content="Turtle Lvr">
 <meta name="robots" content="we welcome our robot overlords"/>
 <meta name="description" content="Exposition on the awesomeness of turtles"/>
+<meta name="keywords" content="turtles, are, awesome" />
 
 <link rel="canonical" href="http://example.com/turtles" />
 <link rel="publisher" href="https://mediawiki.org"/>
@@ -24,7 +25,13 @@
 <meta property="og:url" content="http://example.com" />
 <meta property="og:site_name" content="Awesome Turtles Website" />
 <meta property="og:image" content="http://example.com/turtle.jpg" />
+<meta property="og:image:secure_url" content="https://secure.example.com/turtle.jpg" />
+<meta property="og:image:type" content="image/jpeg" />
+<meta property="og:image:width" content="400" />
+<meta property="og:image:height" content="300" />
 <meta property="og:image" content="http://example.com/shell.jpg" />
+<meta property="og:image:width" content="200" />
+<meta property="og:image:height" content="150" />
 
 <meta property="article:tag" content="turtles" />
 <meta property="article:tag" content="are" />
@@ -53,7 +60,7 @@
 <meta name="DC.Creator" content="http://www.example.com/turtlelvr" >
 <meta name="DC.Description" content="Exposition on the awesomeness of turtles" >
 <meta name="DC.Date" content="2012-02-04 12:00:00" >
-<meta name="DC.Type" content="Article" >
+<meta name="DC.Type" content="Text.Article" >
 
 </head>
 

--- a/test_files/turtle_movie.html
+++ b/test_files/turtle_movie.html
@@ -1,0 +1,63 @@
+<html lang="en">
+
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# video: http://ogp.me/ns/video#">
+
+<meta charset="utf-8">
+
+<title>Turtles are AWESOME!!1 | Awesome Turtles Website</title>
+
+<meta name="author" content="Turtle Lvr">
+<meta name="robots" content="we welcome our robot overlords"/>
+<meta name="description" content="Exposition on the awesomeness of turtles"/>
+<meta name="keywords" content="turtle, movie" />
+
+<link rel="canonical" href="http://example.com/turtles" />
+<link rel="publisher" href="https://mediawiki.org"/>
+<link rel="author" href="http://examples.com/turtlelvr"/>
+<link rel="shortlink" href="http://example.com/c" />
+
+<!--Open Graph-->
+
+<meta property="og:locale" content="en_US" />
+<meta property="og:type" content="video.movie" />
+<meta property="og:title" content="Turtles of the Jungle" />
+<meta property="og:description" content="A 2008 film about jungle turtles." />
+<meta property="og:url" content="http://example.com" />
+<meta property="og:site_name" content="Awesome Turtle Movies Website" />
+<meta property="og:image" content="http://example.com/turtle.jpg" />
+<meta property="og:image" content="http://example.com/shell.jpg" />
+
+<meta property="video:tag" content="turtle" />
+<meta property="video:tag" content="movie" />
+<meta property="video:tag" content="awesome" />
+<meta property="video:director" content="http://www.example.com/PhilTheTurtle" />
+<meta property="video:actor" content="http://www.example.com/PatTheTurtle" />
+<meta property="video:actor" content="http://www.example.com/SaminaTheTurtle" />
+<meta property="video:writer" content="http://www.example.com/TinaTheTurtle" />
+<meta property="video:release_date" content="2015-01-14T19:14:27+00:00" />
+<meta property="video:duration"  content="1000000" />
+
+<!--Twitter-->
+
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@Turtlessssssssss">
+<meta name="twitter:creator" content="@Turtlessssssssss">
+<meta name="twitter:url" content="http://www.example.com/turtles">
+<meta name="twitter:title" content="Turtles of the Jungle">
+<meta name="twitter:description" content="A 2008 film about jungle turtles.">
+
+<!--Dublin Core-->
+
+<meta name="DC.Title" content="Turtles of the Jungle" >
+<meta name="DC.Creator" content="http://www.example.com/turtlelvr" >
+<meta name="DC.Description" content="A 2008 film about jungle turtles." >
+<meta name="DC.Date" content="2012-02-04 12:00:00" >
+<meta name="DC.Type" content="Image.Moving" >
+
+
+</head>
+
+<body>
+</body>
+
+</html>

--- a/test_files/turtles.html
+++ b/test_files/turtles.html
@@ -22,7 +22,7 @@
 <meta property="og:title" content="Turtles are AWESOME!!1" />
 <meta property="og:description" content="Exposition on the awesomeness of turtles" />
 <meta property="og:url" content="http://example.com" />
-<meta property="og:site_name" content="Awesome Turtles Webite" />
+<meta property="og:site_name" content="Awesome Turtles Website" />
 <meta property="og:image" content="http://example.com/turtle.jpg" />
 <meta property="og:image" content="http://example.com/shell.jpg" />
 


### PR DESCRIPTION
Switches to a native open graph implementation

Differences from previous implementation:
* Includes values from item types (i.e.
'article' namespace if value of og:type
is 'article'.
* Doesn't read custom namespaces or verticals

All item type properties are top-level.