### PR TITLE
Some minor fixes + a simple test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+coverage
+node_modules
+npm-debug.log

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+coverage
+node_modules
+test

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,22 @@
+{
+	"bitwise": true,
+	"laxbreak": true,
+	"curly": true,
+	"eqeqeq": true,
+	"immed": true,
+	"latedef": "nofunc",
+	"newcap": true,
+	"noarg": true,
+	"noempty": true,
+	"nonew": true,
+	"regexp": false,
+	"undef": true,
+	"strict": true,
+	"trailing": true,
+	"smarttabs": true,
+	"multistr": true,
+	"node": true,
+	"nomen": false,
+	"loopfunc": true,
+	"esnext": true
+}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
  * https://github.com/wikimedia/html-metadata
  */
 
+'use strict';
+
 var async = require('async'),
 	cheerio = require('cheerio'),
 	request = require('request'),
@@ -11,7 +13,7 @@ var async = require('async'),
 // Default exported function
 exports = module.exports = function(urlOrOpts, callback){
 	request(urlOrOpts, function(error, response, html){
-		chtml = cheerio.load(html);
+		var chtml = cheerio.load(html);
 		exports.parseAll(chtml, function(err, results){
 			callback(err, results);
 		});
@@ -40,7 +42,7 @@ exports.parseAllMerged = function(chtml, callback){
 				// Merge results into larger object
 				for (var key in results){
 					merged = allMetadata[key];
-					value = results[key];
+					var value = results[key];
 
 					if (!merged){
 						merged = [];
@@ -178,9 +180,9 @@ exports.parseOpenGraph = function(chtml, callback){
 		}
 
 		// If the element isn't in namespace, exit
-		if (!typeof namespace.indexOf(propertyValue[0]) === 'number'){return; }
+		if (typeof namespace.indexOf(propertyValue[0]) !== 'number'){return; }
 
-		content = element.attr('content');
+		var content = element.attr('content');
 
 		if (propertyValue.length === 2){
 			property = propertyValue[1]; // Set property to value after namespace
@@ -260,7 +262,7 @@ if (require.main === module) {
 		scrape = exports;
 
 	console.log('Parser running on test file');
-	$ = cheerio.load(fs.readFileSync('./test_files/turtle_movie.html'));
+	var $ = cheerio.load(fs.readFileSync('./test_files/turtle_movie.html'));
 	exports.parseAll($, function(err, results){
 		console.log(JSON.stringify(results));
 	});

--- a/package.json
+++ b/package.json
@@ -9,8 +9,15 @@
 		"microdata-node" : "0.1.2",
 		"request" : "2.49.0"
 	},
+	"devDependencies": {
+		"mocha": "~1.x.x",
+		"mocha-jshint": "0.0.9",
+		"istanbul": "0.3.5",
+		"mocha-lcov-reporter": "0.0.1"
+	},
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "mocha",
+		"coverage": "istanbul cover _mocha -- -R spec"
 	},
 	"keywords": [
 		"open graph",

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var meta = require('../index');
+var cheerio = require('cheerio');
+var request = require('request');
+
+// Run jshint as part of normal testing
+require('mocha-jshint')();
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+describe('scraping', function() {
+
+	var url = 'http://fortune.com/2015/02/20/nobel-prize-economics-for-sale/';
+
+	it('should get OpenGraph info', function(done) {
+		request(url, function(error, response) {
+			var ch = cheerio.load(response.body);
+			meta.parseOpenGraph(ch, function(res) {
+				// check for some properties
+				['title', 'description', 'author'].forEach(function(key) {
+					if(!res[key]) {
+						throw new Error('Expected to find the ' + key + ' key in the reponse!');
+					}
+				});
+				done();
+			});
+		});
+	});
+
+});
+


### PR DESCRIPTION
This PR fixes some minor code issues and adds a `.gitignore` file. Furthermore, it adds a simple test suite using [mocha](https://github.com/mochajs/mocha) and code coverage via [istanbul](https://github.com/gotwarlost/istanbul):

* `npm test` runs the tests
* `npm run-script coverage` runs the tests and reports code coverage

Note that currently there are only two tests: a `jshint` check and a superficial test downloading an article with meta-data, parsing it using `parseOpenGraph` and checking if some fields are present in the response. Needless to say, this should be considered only the beginning - we should develop more tests (at least one for each exported function), and also be more strict (tests should check corner cases as well as common use-cases).