### PR TITLE
Prevent non-og tags from being added

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,9 @@ exports.parseOpenGraph = function(chtml, callback){
 		}
 
 		// If the element isn't in namespace, exit
-		if (typeof namespace.indexOf(propertyValue[0]) !== 'number'){return; }
+		if (namespace.indexOf(propertyValue[0]) < 0){
+			return;
+		}
 
 		var content = element.attr('content');
 

--- a/package.json
+++ b/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "html-metadata",
-  "version": "0.1.1",
-  "description": "Scrapes metadata of several different standards",
-  "main": "index.js",
-  "dependencies": {
-    "async": "0.9.0",
-    "cheerio": "0.18.0",
-    "microdata-node": "0.1.2",
-    "request": "2.49.0"
-  },
-  "devDependencies": {
-    "mocha": "~1.x.x",
-    "mocha-jshint": "0.0.9",
-    "istanbul": "0.3.5",
-    "mocha-lcov-reporter": "0.0.1"
-  },
-  "scripts": {
-    "test": "mocha",
-    "coverage": "istanbul cover _mocha -- -R spec"
-  },
-  "keywords": [
-    "open graph",
-    "metadata",
-    "microdata",
-    "dublin core",
-    "web scraper"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/wikimedia/html-metadata.git"
-  },
-  "author": "Marielle Volz <marielle.volz@gmail.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/wikimedia/html-metadata/issues"
-  },
-  "homepage": "https://github.com/wikimedia/html-metadata"
+	"name": "html-metadata",
+	"version": "0.1.2",
+	"description": "Scrapes metadata of several different standards",
+	"main": "index.js",
+	"dependencies": {
+		"async": "0.9.0",
+		"cheerio" : "0.18.0",
+		"microdata-node" : "0.1.2",
+		"request" : "2.49.0"
+	},
+	"devDependencies": {
+		"mocha": "~1.x.x",
+		"mocha-jshint": "0.0.9",
+		"istanbul": "0.3.5",
+		"mocha-lcov-reporter": "0.0.1"
+	},
+	"scripts": {
+		"test": "mocha",
+		"coverage": "istanbul cover _mocha -- -R spec"
+	},
+	"keywords": [
+		"open graph",
+		"metadata",
+		"microdata",
+		"dublin core",
+		"web scraper"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/wikimedia/html-metadata.git"
+	},
+	"author": "Marielle Volz <marielle.volz@gmail.com>",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/wikimedia/html-metadata/issues"
+	},
+	"homepage": "https://github.com/wikimedia/html-metadata"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,8 @@
 var meta = require('../index');
 var cheerio = require('cheerio');
 var request = require('request');
+var util = require('util');
+
 
 // Run jshint as part of normal testing
 require('mocha-jshint')();
@@ -12,9 +14,9 @@ require('mocha-jshint')();
 
 describe('scraping', function() {
 
-	var url = 'http://fortune.com/2015/02/20/nobel-prize-economics-for-sale/';
-
 	it('should get OpenGraph info', function(done) {
+		var url = 'http://fortune.com/2015/02/20/nobel-prize-economics-for-sale/';
+
 		request(url, function(error, response) {
 			var ch = cheerio.load(response.body);
 			meta.parseOpenGraph(ch, function(res) {
@@ -22,6 +24,27 @@ describe('scraping', function() {
 				['title', 'description', 'author'].forEach(function(key) {
 					if(!res[key]) {
 						throw new Error('Expected to find the ' + key + ' key in the reponse!');
+					}
+				});
+				done();
+			});
+		});
+	});
+
+	it('should get OpenGraph image tags correctly', function(done) {
+		var url = 'http://www.lemonde.fr';
+
+		request(url, function(error, response) {
+			var ch = cheerio.load(response.body);
+			var expectedImage = '{"url":"http://s1.lemde.fr/medias/web/1.2.672/img/placeholder/opengraph.jpg"}';
+			meta.parseOpenGraph(ch, function(res) {
+				// check for some properties
+				['image'].forEach(function(key) {
+					if(!res[key]) {
+						throw new Error('Expected to find the ' + key + ' key in the reponse!');
+					}
+					if (JSON.stringify(res[key])!== expectedImage){
+						throw new Error('Unexpected result');
 					}
 				});
 				done();


### PR DESCRIPTION
Non open graph tags were being added in
some cases, because indexOf returns -1
for items not in the list and code was
assuming a non-number value.

Added case in test for this in test/index.js
as this was where issue was initially detected.

Partially addresses issue #16.