### PR TITLE
Always add subproperties to the correct root

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,6 +169,9 @@ exports.parseOpenGraph = function(chtml, callback){
 			audio : 'url'
 		};
 
+	var roots = {}; // Object to store roots of different type i.e. image, audio
+	var subProp; // Current subproperty of interest
+
 	metaTags.each(function() {
 		element = chtml(this);
 		propertyValue = element.attr('property');
@@ -180,7 +183,7 @@ exports.parseOpenGraph = function(chtml, callback){
 		}
 
 		// If the element isn't in namespace, exit
-		if (namespace.indexOf(propertyValue[0]) < 0){
+		if (namespace.indexOf(propertyValue[0]) < 0){ //
 			return;
 		}
 
@@ -188,13 +191,12 @@ exports.parseOpenGraph = function(chtml, callback){
 
 		if (propertyValue.length === 2){
 			property = propertyValue[1]; // Set property to value after namespace
-			if (property in subProperty){ // If one of image,video,audio
+			if (property in subProperty){ // If has valid subproperty
 				node = {};
 				node[subProperty[property]] = content;
-				root = node; // Set as potential root
+				roots[property] = node;
 			} else {
 				node = content;
-				root = false; // Clear root- subproperties must occur directly after root tag is declared
 			}
 			// If the property already exists, make the array of contents
 			if (meta[property]) {
@@ -206,10 +208,13 @@ exports.parseOpenGraph = function(chtml, callback){
 			} else {
 				meta[property] = node;
 			}
-		} else if (propertyValue.length === 3){ // Property part of a verticle
-			if (root){ // If root exists, add properties to root
-				property = propertyValue[2];
-				root[property] = content; // If multiple tags present, overwrites previous one. These should be unique.
+		} else if (propertyValue.length === 3){ // Property part of a vertical
+			subProp = propertyValue[1]; // i.e. image, audio
+			property = propertyValue[2]; // i.e. height, width
+			// If root for subproperty exists, and there isn't already a property
+			// called that in there already i.e. height, add property and content.
+			if (roots[subProp] && !roots[subProp][property]){
+				roots[subProp][property] = content;
 			}
 		} else {
 			return; // Discard values with length <2 and >3 as invalid

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "html-metadata",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "Scrapes metadata of several different standards",
 	"main": "index.js",
 	"dependencies": {

--- a/test/static.js
+++ b/test/static.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Tests using files contained in ./static
+ */
+
+var cheerio = require('cheerio');
+var meta = require('../index');
+var util = require('util');
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+describe('static files', function() {
+	var fs = require('fs');
+
+	it('should get correct info from turtle movie file', function(done) {
+		var expected = '{"dublinCore":{"title":"Turtles of the Jungle","creator":"http://www.example.com/turtlelvr","description":"A 2008 film about jungle turtles.","date":"2012-02-04 12:00:00","type":"Image.Moving"},"general":{"author":"Turtle Lvr","authorlink":"http://examples.com/turtlelvr","canonical":"http://example.com/turtles","description":"Exposition on the awesomeness of turtles","publisher":"https://mediawiki.org","robots":"we welcome our robot overlords","shortlink":"http://example.com/c","title":"Turtles are AWESOME!!1 | Awesome Turtles Website"},"schemaOrg":{"items":[]},"openGraph":{"locale":"en_US","type":"video.movie","title":"Turtles of the Jungle","description":"A 2008 film about jungle turtles.","url":"http://example.com","site_name":"Awesome Turtle Movies Website","image":[{"url":"http://example.com/turtle.jpg"},{"url":"http://example.com/shell.jpg"}],"tag":["turtle","movie","awesome"],"director":"http://www.example.com/PhilTheTurtle","actor":["http://www.example.com/PatTheTurtle","http://www.example.com/SaminaTheTurtle"],"writer":"http://www.example.com/TinaTheTurtle","release_date":"2015-01-14T19:14:27+00:00","duration":"1000000"}}';
+		var $ = cheerio.load(fs.readFileSync('./test_files/turtle_movie.html'));
+		meta.parseAll($, function(err, results){
+			if (JSON.stringify(results) !== expected){
+				console.log(util.inspect(results, false, null));
+				throw new Error('Unexpected Results');
+			}
+			done();
+		});
+	});
+
+	it('should get correct info from turtle article file', function(done) {
+		var expected = '{"dublinCore":{"title":"Turtles are AWESOME!!1","creator":"http://www.example.com/turtlelvr","description":"Exposition on the awesomeness of turtles","date":"2012-02-04 12:00:00","type":"Text.Article"},"general":{"author":"Turtle Lvr","authorlink":"http://examples.com/turtlelvr","canonical":"http://example.com/turtles","description":"Exposition on the awesomeness of turtles","publisher":"https://mediawiki.org","robots":"we welcome our robot overlords","shortlink":"http://example.com/c","title":"Turtles are AWESOME!!1 | Awesome Turtles Website"},"schemaOrg":{"items":[]},"openGraph":{"locale":"en_US","type":"article","title":"Turtles are AWESOME!!1","description":"Exposition on the awesomeness of turtles","url":"http://example.com","site_name":"Awesome Turtles Website","image":[{"url":"http://example.com/turtle.jpg","secure_url":"https://secure.example.com/turtle.jpg","type":"image/jpeg","width":"400","height":"300"},{"url":"http://example.com/shell.jpg","width":"200","height":"150"}],"audio":{"url":"http://example.com/sound.mp3","secure_url":"https://secure.example.com/sound.mp3","type":"audio/mpeg"},"tag":["turtles","are","awesome"],"section":["Turtles are tough","Turtles are flawless","Turtles are cute"],"published_time":"2012-02-04T12:00:00+00:00","modified_time":"2015-01-14T19:14:27+00:00","author":"http://examples.com/turtlelvr","publisher":"http://mediawiki.org"}}';
+		var $ = cheerio.load(fs.readFileSync('./test_files/turtle_article.html'));
+		meta.parseAll($, function(err, results){
+			if (JSON.stringify(results) !== expected){
+				console.log(util.inspect(results, false, null));
+				throw new Error('Unexpected Results');
+			}
+			done();
+		});
+
+	});
+});
+

--- a/test_files/turtle_article.html
+++ b/test_files/turtle_article.html
@@ -24,15 +24,26 @@
 <meta property="og:description" content="Exposition on the awesomeness of turtles" />
 <meta property="og:url" content="http://example.com" />
 <meta property="og:site_name" content="Awesome Turtles Website" />
+<!--Image subproperty tags with no root -->
+<meta property="og:image:width" content="666" /> <!--Ignored-->
+<meta property="og:image:height" content="666" /> <!--Ignored-->
 <meta property="og:image" content="http://example.com/turtle.jpg" />
 <meta property="og:image:secure_url" content="https://secure.example.com/turtle.jpg" />
 <meta property="og:image:type" content="image/jpeg" />
 <meta property="og:image:width" content="400" />
+<meta property="og:image:width" content="666" /> <!--Ignored-->
 <meta property="og:image:height" content="300" />
 <meta property="og:image" content="http://example.com/shell.jpg" />
+<!--Interrupt image tags with audio tags-->
+<meta property="og:audio" content="http://example.com/sound.mp3" />
+<meta property="og:audio:secure_url" content="https://secure.example.com/sound.mp3" />
+<meta property="og:audio:type" content="audio/mpeg" />
+<!--End interruption with audio tags -->
 <meta property="og:image:width" content="200" />
 <meta property="og:image:height" content="150" />
-
+<!--Invalid subproperty-->
+<meta property="og:cat:meow" content="purr" /><!--Ignored-->
+<!--Article vertical-->
 <meta property="article:tag" content="turtles" />
 <meta property="article:tag" content="are" />
 <meta property="article:tag" content="awesome" />
@@ -44,6 +55,14 @@
 <meta property="article:author"  content="http://examples.com/turtlelvr" />
 <meta property="article:publisher"  content="http://mediawiki.org" />
 
+<!--AL-->
+
+<meta property="al:ios:url" content="turtle://">
+<meta property="al:ios:app_store_id" content="000">
+<meta property="al:android:url" content="turtle://">
+<meta property="al:android:package" content="superturtlearticle.androidapp">
+<meta property="al:web:url" content="http://example.com/">
+<meta property="al:web:should_fallback" content="true">
 
 <!--Twitter-->
 

--- a/test_files/turtle_movie.html
+++ b/test_files/turtle_movie.html
@@ -32,10 +32,20 @@
 <meta property="video:tag" content="awesome" />
 <meta property="video:director" content="http://www.example.com/PhilTheTurtle" />
 <meta property="video:actor" content="http://www.example.com/PatTheTurtle" />
+<meta property="video:actor:role" content="Turtle #3" /> <!-- Currently ignored -->
 <meta property="video:actor" content="http://www.example.com/SaminaTheTurtle" />
 <meta property="video:writer" content="http://www.example.com/TinaTheTurtle" />
 <meta property="video:release_date" content="2015-01-14T19:14:27+00:00" />
 <meta property="video:duration"  content="1000000" />
+
+<!--AL-->
+
+<meta property="al:ios:url" content="turtle://">
+<meta property="al:ios:app_store_id" content="000">
+<meta property="al:android:url" content="turtle://">
+<meta property="al:android:package" content="superturtlearticle.androidapp">
+<meta property="al:web:url" content="http://example.com/">
+<meta property="al:web:should_fallback" content="true">
 
 <!--Twitter-->
 


### PR DESCRIPTION
Previously, subproperties were added to whatever
root was created directly before them. Now checks to
make sure the subproperty names match, e.g.
og:image:width only gets added to the most recent
og:image and not og:audio.

Also switched from overwriting latest sub-subproperty e.g.
og:image:width to keeping first og:image:width added.

Added bad data to test_files and, and added tests
of those files to verify that data is correctly
added.

Issue #16