### PR TITLE
Make library compatible with callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 html-metadata
 =============
 
-# MetaData html scraper and parser for Node.js (promise-based)
+# MetaData html scraper and parser for Node.js (supports Promises and callback style)
 
-The aim of this library is to be a comprehensive source for extracting all html embedded metadata. Currently it supports Schema.org microdata using third party libraries, a native Dublin Core and Open Graph implementation, and some general metadata that doesn't belong to a particular standard (for instance, the content of the title tag, or meta description tags).
+The aim of this library is to be a comprehensive source for extracting all html embedded metadata. Currently it supports Schema.org microdata using a third party library, a native Dublin Core and Open Graph implementation, and some general metadata that doesn't belong to a particular standard (for instance, the content of the title tag, or meta description tags).
 
-Planned is support for  RDFa , twitter, AGLS, eprints, highwire, BEPress and other yet unheard of metadata types. Contributions and requests for other metadata types welcome!
+Planned is support for  COinS, RDFa , twitter, AGLS, eprints, highwire, BEPress and other yet unheard of metadata types. Contributions and requests for other metadata types welcome!
 
 ## Install
 
 	npm install git://github.com/mvolz/html-metadata.git
 
 ## Usage
+
+Promise-based:
 
 ```js
 var scrape = require('html-metadata');
@@ -20,12 +22,40 @@ var url = "http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usab
 
 scrape(url).then(function(metadata){
 	console.log(metadata);
-	});
-})
+});
+```
+
+Callback-based:
+
+```js
+var scrape = require('html-metadata');
+
+var url = "http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/";
+
+scrape(url, function(error, metadata){
+	console.log(metadata);
+});
 ```
 
 The scrape method used here invokes the parseAll() method, which uses all the available methods registered in method metadataFunctions(), and are available for use separately as well, for example:
 
+Promise-based:
+```js
+var cheerio = require('cheerio');
+var preq = require('preq'); // Promisified request library
+var dublinCore = require('html-metadata').parseDublinCore;
+
+var url = "http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/";
+
+preq(url).then(function(response){
+	$ = cheerio.load(response.body);
+	return parseDublinCore($).then(function(metadata){
+		console.log(metadata);
+	});
+});
+```
+
+Callback-based:
 ```js
 var cheerio = require('cheerio');
 var request = require('request');
@@ -35,10 +65,10 @@ var url = "http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usab
 
 request(url, function(error, response, html){
 	$ = cheerio.load(html);
-	parseDublinCore($).then(function(results){
-		console.log(results);
+	parseDublinCore($, function(error, metadata){
+		console.log(metadata);
 	});
-```
+});
 
 The method parseGeneral obtains the following general metadata:
 

--- a/index.js
+++ b/index.js
@@ -1,259 +1,99 @@
 #!/usr/bin/env node
 /**
  * https://github.com/wikimedia/html-metadata
+ *
+ * This file wraps all exportable functions so that they
+ * can be used either with Promises or with callbacks.
  */
 
 'use strict';
 
+/*
+Import modules
+ */
 var BBPromise = require('bluebird');
 var cheerio = require('cheerio');
 var preq = require('preq'); // Promisified Request library
-var microdata = require('microdata-node'); // Schema.org microdata
 
-// Default exported function
-exports = module.exports = function(urlOrOpts) {
+var index = require('./lib/index.js');
+
+/**
+ * Default exported function that takes a url string or
+ * request library options object and returns a
+ * BBPromise for all available metadata
+ *
+ * @param  {Object}   urlOrOpts  url String or options Object
+ * @param  {Function} [callback] Optional callback
+ * @return {Object}              BBPromise for metadata
+ */
+exports = module.exports = function(urlOrOpts, callback) {
 	return preq.get(urlOrOpts
 	).then(function(callRes) {
-		return exports.parseAll(cheerio.load(callRes.body));
-	});
+		return index.parseAll(cheerio.load(callRes.body));
+	}).nodeify(callback);
 };
 
 /**
  * Returns Object containing all available datatypes, keyed
  * using the same keys as in metadataFunctions.
  *
- * @param  {Object}   chtml html Cheerio object to parse
- * @return {Object}         contains metadata
+ * @param  {Object}   chtml      html Cheerio object to parse
+ * @param  {Function} [callback] optional callback function
+ * @return {Object}              BBPromise for metadata
  */
-exports.parseAll = function(chtml){
-
-	var keys = Object.keys(exports.metadataFunctions); // Array of keys corresponding to position of promise in arr
-	var meta = {}; // Metadata keyed by keys in exports.metadataFunctions
-	// Array of promises for metadata of each type in exports.metadataFunctions
-	var arr = keys.map(function(key) {
-		return exports.metadataFunctions[key](chtml);
-	});
-
-	var result; // Result in for loop over results
-	var key; // Key corrsponding to location of result
-	return BBPromise.settle(arr)
-		.then(function(results){
-			for (var r in results){
-				result = results[r];
-				key = keys[r];
-				if (result && result.isFulfilled() && result.value()) {
-					meta[key] = result.value();
-				}
-			}
-			if (Object.keys(meta).length === 0){
-				throw new Error("No metadata found in page");
-			}
-			return BBPromise.resolve(meta);
-		});
+exports.parseAll = function(chtml, callback){
+	return index.parseAll(chtml).nodeify(callback);
 };
 
 /**
  * Scrapes Dublin Core data given Cheerio loaded html object
- * @param  {Object}   chtml html Cheerio object
- * @return {Object}         promise of dc metadata
+ *
+ * @param  {Object}   chtml      html Cheerio object
+ * @param  {Function} [callback] optional callback function
+ * @return {Object}              BBPromise for metadata
  */
-exports.parseDublinCore = BBPromise.method(function(chtml){
-
-	var meta = {};
-	var metaTags = chtml('meta,link');
-	var reason = new Error('No Dublin Core metadata found in page');
-
-	if (!metaTags || metaTags.length === 0){throw reason;}
-
-	metaTags.each(function() {
-		var element = chtml(this),
-			isLink = this.name === 'link',
-			nameAttr = element.attr(isLink ? 'rel' : 'name');
-
-		// If the element isn't a Dublin Core property, skip it
-		if (!nameAttr
-			|| (nameAttr.substring(0, 3).toUpperCase() !== 'DC.'
-				&& nameAttr.substring(0, 8).toUpperCase() !== 'DCTERMS.')) {
-			return;
-		}
-
-		var property = nameAttr.substring(nameAttr.lastIndexOf('.') + 1),
-			content = element.attr(isLink ? 'href' : 'content');
-
-		// Lowercase the first character
-		property = property.charAt(0).toLowerCase() + property.substr(1);
-
-		// If the property already exists, make the array of contents
-		if (meta[property]) {
-			if (meta[property] instanceof Array) {
-				meta[property].push(content);
-			} else {
-				meta[property] = [meta[property], content];
-			}
-		} else {
-			meta[property] = content;
-		}
-	});
-	if (Object.keys(meta).length === 0){
-		throw reason;
-	}
-	return meta;
-});
+exports.parseDublinCore = function(chtml, callback){
+	return index.parseDublinCore(chtml).nodeify(callback);
+};
 
 /**
  * Scrapes general metadata terms given Cheerio loaded html object
- * @param  {Object}   chtml html Cheerio object
- * @return {Object}         object contain general metadata
+ *
+ * @param  {Object}   chtml      html Cheerio object
+ * @param  {Function} [callback] optional callback function
+ * @return {Object}              BBPromise for metadata
  */
-exports.parseGeneral = BBPromise.method(function(chtml){
-
-	var clutteredMeta = {
-		author: chtml('meta[name=author]').first().attr('content'), //author <meta name="author" content="">
-		authorlink: chtml('link[rel=author]').first().attr('href'), //author link <link rel="author" href="">
-		canonical: chtml('link[rel=canonical]').first().attr('href'), //canonical link <link rel="canonical" href="">
-		description: chtml('meta[name=description]').attr('content'), //meta description <meta name ="description" content="">
-		publisher: chtml('link[rel=publisher]').first().attr('href'), //publisher link <link rel="publisher" href="">
-		robots: chtml('meta[name=robots]').first().attr('content'), //robots <meta name ="robots" content="">
-		shortlink: chtml('link[rel=shortlink]').first().attr('href'), //short link <link rel="shortlink" href="">
-		title: chtml('title').first().text(), //title tag <title>
-	};
-
-	// Copy key-value pairs with defined values to meta
-	var meta = {};
-	var value;
-	Object.keys(clutteredMeta).forEach(function(key){
-		value = clutteredMeta[key];
-		if (value){
-			meta[key] = value;
-		}
-	});
-
-	// Reject promise if meta is empty
-	if (Object.keys(meta).length === 0){
-		throw new Error('No general metadata found in page');
-	}
-
-	// Resolve on meta
-	return meta;
-});
+exports.parseGeneral = function(chtml, callback){
+	return index.parseGeneral(chtml).nodeify(callback);
+};
 
 /**
  * Scrapes OpenGraph data given html object
- * @param  {Object}   chtml html Cheerio object
- * @return {Object}         promise of open graph metadata object
+ *
+ * @param  {Object}   chtml      html Cheerio object
+ * @param  {Function} [callback] optional callback function
+ * @return {Object}              BBPromise for metadata
  */
-exports.parseOpenGraph = BBPromise.method(function(chtml){
-
-	var element;
-	var itemType;
-	var propertyValue;
-	var property;
-	var node;
-	var meta = {};
-	var metaTags = chtml('meta');
-	var namespace = ['og','fb'];
-	var subProperty = {
-			image : 'url',
-			video : 'url',
-			audio : 'url'
-		};
-	var roots = {}; // Object to store roots of different type i.e. image, audio
-	var subProp; // Current subproperty of interest
-	var reason = new Error('No openGraph metadata found in page');
-
-	if (!metaTags || metaTags.length === 0){ throw reason; }
-
-	metaTags.each(function() {
-		element = chtml(this);
-		propertyValue = element.attr('property');
-
-		if (!propertyValue){
-			return;
-		} else {
-			propertyValue = propertyValue.toLowerCase().split(':');
-		}
-
-		// If the element isn't in namespace, exit
-		if (namespace.indexOf(propertyValue[0]) < 0){
-			return;
-		}
-
-		var content = element.attr('content');
-
-		if (propertyValue.length === 2){
-			property = propertyValue[1]; // Set property to value after namespace
-			if (property in subProperty){ // If has valid subproperty
-				node = {};
-				node[subProperty[property]] = content;
-				roots[property] = node;
-			} else {
-				node = content;
-			}
-			// If the property already exists, make the array of contents
-			if (meta[property]) {
-				if (meta[property] instanceof Array) {
-					meta[property].push(node);
-				} else {
-					meta[property] = [meta[property], node];
-				}
-			} else {
-				meta[property] = node;
-			}
-		} else if (propertyValue.length === 3){ // Property part of a vertical
-			subProp = propertyValue[1]; // i.e. image, audio
-			property = propertyValue[2]; // i.e. height, width
-			// If root for subproperty exists, and there isn't already a property
-			// called that in there already i.e. height, add property and content.
-			if (roots[subProp] && !roots[subProp][property]){
-				roots[subProp][property] = content;
-			}
-		} else {
-			return; // Discard values with length <2 and >3 as invalid
-		}
-
-		// Check for "type" property and add to namespace if so
-		// If any of these type occur in order before the type attribute is defined,
-		// they'll be skipped; spec requires they be placed below type definition.
-		// For nested types (e.g. video.movie) the OG protocol uses the super type
-		// (e.g. movie) as the new namespace.
-		if (property === 'type'){
-			namespace.push(content.split('.')[0]); // Add the type to the acceptable namespace list
-		}
-	});
-	if (Object.keys(meta).length === 0){
-		throw reason;
-	}
-	return meta;
-});
-
+exports.parseOpenGraph = function(chtml, callback){
+	return index.parseOpenGraph(chtml).nodeify(callback);
+};
 
 /**
  * Scrapes schema.org microdata given Cheerio loaded html object
- * @param  {Object}  chtml Cheerio object with html loaded
- * @return {Object}        promise of schema.org microdata object
+ *
+ * @param  {Object}   chtml      html Cheerio object
+ * @param  {Function} [callback] optional callback function
+ * @return {Object}              BBPromise for metadata
  */
-exports.parseSchemaOrgMicrodata = BBPromise.method(function(chtml){
-	if (!chtml){
-		throw new Error('Undefined argument');
-	}
-
-	var meta = microdata.parse(chtml);
-	if (!meta || !meta.items || !meta.items[0]){
-		throw new Error('No schema.org metadata found in page');
-	}
-	return meta;
-});
+exports.parseSchemaOrgMicrodata = function(chtml, callback){
+	return index.parseSchemaOrgMicrodata(chtml).nodeify(callback);
+};
 
 /**
  * Global exportable list of scraping promises with string keys
  * @type {Object}
  */
-exports.metadataFunctions = {
-	'dublinCore': exports.parseDublinCore,
-	'general': exports.parseGeneral,
-	'schemaOrg': exports.parseSchemaOrgMicrodata,
-	'openGraph': exports.parseOpenGraph
-};
+exports.metadataFunctions = index.metadataFunctions;
 
 /*
   Export the version

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * https://github.com/wikimedia/html-metadata
+ */
+
+'use strict';
+
+var BBPromise = require('bluebird');
+var cheerio = require('cheerio');
+var preq = require('preq'); // Promisified Request library
+var microdata = require('microdata-node'); // Schema.org microdata
+
+/**
+ * Returns Object containing all available datatypes, keyed
+ * using the same keys as in metadataFunctions.
+ *
+ * @param  {Object}   chtml html Cheerio object to parse
+ * @return {Object}         contains metadata
+ */
+exports.parseAll = function(chtml){
+
+	var keys = Object.keys(exports.metadataFunctions); // Array of keys corresponding to position of promise in arr
+	var meta = {}; // Metadata keyed by keys in exports.metadataFunctions
+	// Array of promises for metadata of each type in exports.metadataFunctions
+	var arr = keys.map(function(key) {
+		return exports.metadataFunctions[key](chtml);
+	});
+
+	var result; // Result in for loop over results
+	var key; // Key corrsponding to location of result
+	return BBPromise.settle(arr)
+		.then(function(results){
+			for (var r in results){
+				result = results[r];
+				key = keys[r];
+				if (result && result.isFulfilled() && result.value()) {
+					meta[key] = result.value();
+				}
+			}
+			if (Object.keys(meta).length === 0){
+				throw new Error("No metadata found in page");
+			}
+			return BBPromise.resolve(meta);
+		});
+};
+
+/**
+ * Scrapes Dublin Core data given Cheerio loaded html object
+ * @param  {Object}   chtml html Cheerio object
+ * @return {Object}         promise of dc metadata
+ */
+exports.parseDublinCore = BBPromise.method(function(chtml){
+
+	var meta = {};
+	var metaTags = chtml('meta,link');
+	var reason = new Error('No Dublin Core metadata found in page');
+
+	if (!metaTags || metaTags.length === 0){throw reason;}
+
+	metaTags.each(function() {
+		var element = chtml(this),
+			isLink = this.name === 'link',
+			nameAttr = element.attr(isLink ? 'rel' : 'name');
+
+		// If the element isn't a Dublin Core property, skip it
+		if (!nameAttr
+			|| (nameAttr.substring(0, 3).toUpperCase() !== 'DC.'
+				&& nameAttr.substring(0, 8).toUpperCase() !== 'DCTERMS.')) {
+			return;
+		}
+
+		var property = nameAttr.substring(nameAttr.lastIndexOf('.') + 1),
+			content = element.attr(isLink ? 'href' : 'content');
+
+		// Lowercase the first character
+		property = property.charAt(0).toLowerCase() + property.substr(1);
+
+		// If the property already exists, make the array of contents
+		if (meta[property]) {
+			if (meta[property] instanceof Array) {
+				meta[property].push(content);
+			} else {
+				meta[property] = [meta[property], content];
+			}
+		} else {
+			meta[property] = content;
+		}
+	});
+	if (Object.keys(meta).length === 0){
+		throw reason;
+	}
+	return meta;
+});
+
+/**
+ * Scrapes general metadata terms given Cheerio loaded html object
+ * @param  {Object}   chtml html Cheerio object
+ * @return {Object}         object contain general metadata
+ */
+exports.parseGeneral = BBPromise.method(function(chtml){
+
+	var clutteredMeta = {
+		author: chtml('meta[name=author]').first().attr('content'), //author <meta name="author" content="">
+		authorlink: chtml('link[rel=author]').first().attr('href'), //author link <link rel="author" href="">
+		canonical: chtml('link[rel=canonical]').first().attr('href'), //canonical link <link rel="canonical" href="">
+		description: chtml('meta[name=description]').attr('content'), //meta description <meta name ="description" content="">
+		publisher: chtml('link[rel=publisher]').first().attr('href'), //publisher link <link rel="publisher" href="">
+		robots: chtml('meta[name=robots]').first().attr('content'), //robots <meta name ="robots" content="">
+		shortlink: chtml('link[rel=shortlink]').first().attr('href'), //short link <link rel="shortlink" href="">
+		title: chtml('title').first().text(), //title tag <title>
+	};
+
+	// Copy key-value pairs with defined values to meta
+	var meta = {};
+	var value;
+	Object.keys(clutteredMeta).forEach(function(key){
+		value = clutteredMeta[key];
+		if (value){
+			meta[key] = value;
+		}
+	});
+
+	// Reject promise if meta is empty
+	if (Object.keys(meta).length === 0){
+		throw new Error('No general metadata found in page');
+	}
+
+	// Resolve on meta
+	return meta;
+});
+
+/**
+ * Scrapes OpenGraph data given html object
+ * @param  {Object}   chtml html Cheerio object
+ * @return {Object}         promise of open graph metadata object
+ */
+exports.parseOpenGraph = BBPromise.method(function(chtml){
+
+	var element;
+	var itemType;
+	var propertyValue;
+	var property;
+	var node;
+	var meta = {};
+	var metaTags = chtml('meta');
+	var namespace = ['og','fb'];
+	var subProperty = {
+			image : 'url',
+			video : 'url',
+			audio : 'url'
+		};
+	var roots = {}; // Object to store roots of different type i.e. image, audio
+	var subProp; // Current subproperty of interest
+	var reason = new Error('No openGraph metadata found in page');
+
+	if (!metaTags || metaTags.length === 0){ throw reason; }
+
+	metaTags.each(function() {
+		element = chtml(this);
+		propertyValue = element.attr('property');
+
+		if (!propertyValue){
+			return;
+		} else {
+			propertyValue = propertyValue.toLowerCase().split(':');
+		}
+
+		// If the element isn't in namespace, exit
+		if (namespace.indexOf(propertyValue[0]) < 0){
+			return;
+		}
+
+		var content = element.attr('content');
+
+		if (propertyValue.length === 2){
+			property = propertyValue[1]; // Set property to value after namespace
+			if (property in subProperty){ // If has valid subproperty
+				node = {};
+				node[subProperty[property]] = content;
+				roots[property] = node;
+			} else {
+				node = content;
+			}
+			// If the property already exists, make the array of contents
+			if (meta[property]) {
+				if (meta[property] instanceof Array) {
+					meta[property].push(node);
+				} else {
+					meta[property] = [meta[property], node];
+				}
+			} else {
+				meta[property] = node;
+			}
+		} else if (propertyValue.length === 3){ // Property part of a vertical
+			subProp = propertyValue[1]; // i.e. image, audio
+			property = propertyValue[2]; // i.e. height, width
+			// If root for subproperty exists, and there isn't already a property
+			// called that in there already i.e. height, add property and content.
+			if (roots[subProp] && !roots[subProp][property]){
+				roots[subProp][property] = content;
+			}
+		} else {
+			return; // Discard values with length <2 and >3 as invalid
+		}
+
+		// Check for "type" property and add to namespace if so
+		// If any of these type occur in order before the type attribute is defined,
+		// they'll be skipped; spec requires they be placed below type definition.
+		// For nested types (e.g. video.movie) the OG protocol uses the super type
+		// (e.g. movie) as the new namespace.
+		if (property === 'type'){
+			namespace.push(content.split('.')[0]); // Add the type to the acceptable namespace list
+		}
+	});
+	if (Object.keys(meta).length === 0){
+		throw reason;
+	}
+	return meta;
+});
+
+
+/**
+ * Scrapes schema.org microdata given Cheerio loaded html object
+ * @param  {Object}  chtml Cheerio object with html loaded
+ * @return {Object}        promise of schema.org microdata object
+ */
+exports.parseSchemaOrgMicrodata = BBPromise.method(function(chtml){
+	if (!chtml){
+		throw new Error('Undefined argument');
+	}
+
+	var meta = microdata.parse(chtml);
+	if (!meta || !meta.items || !meta.items[0]){
+		throw new Error('No schema.org metadata found in page');
+	}
+	return meta;
+});
+
+/**
+ * Global exportable list of scraping promises with string keys
+ * @type {Object}
+ */
+exports.metadataFunctions = {
+	'dublinCore': exports.parseDublinCore,
+	'general': exports.parseGeneral,
+	'schemaOrg': exports.parseSchemaOrgMicrodata,
+	'openGraph': exports.parseOpenGraph
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Scrapes metadata of several different standards",
   "main": "index.js",
   "dependencies": {
-    "bluebird": "2.9.24",
+    "bluebird": "2.8.2",
     "cheerio": "0.19.0",
     "microdata-node": "0.1.2",
     "preq": "0.3.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-metadata",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Scrapes metadata of several different standards",
   "main": "index.js",
   "dependencies": {

--- a/test/errors.js
+++ b/test/errors.js
@@ -17,7 +17,7 @@ var assert = require('./utils/assert.js');
 describe('errors', function() {
 
 	it('should not find schema.org metadata, reject promise', function() {
-		var url = 'http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/';
+		var url = 'http://example.com';
 		return preq.get(url)
 		.then(function(callRes) {
 			var $ = cheerio.load(callRes.body);

--- a/test/scraping.js
+++ b/test/scraping.js
@@ -35,7 +35,7 @@ describe('scraping', function() {
 		return meta(url)
 		.catch(function(e){throw e;})
 		.then(function(res) {
-			var expectedImage = '{"url":"http://s1.lemde.fr/medias/web/1.2.672/img/placeholder/opengraph.jpg"}';
+			var expectedImage = '{"url":"http://s1.lemde.fr/medias/web/1.2.677/img/placeholder/opengraph.jpg"}';
 			assert.deepEqual(JSON.stringify(res.openGraph.image), expectedImage);
 		});
 	});


### PR DESCRIPTION
The release of 1.0.0 broke backwards compatibility
by replacing all callbacks with Promises; this
change restores the ability to use all previous
functions like callbacks and retains the ability
of 1.0.0 to use these functions like Promises.

Minor fixes to tests which have broken following
changes in metadata at the given urls.