### PR TITLE
Clean up scraping tests

### DIFF
--- a/test/scraping.js
+++ b/test/scraping.js
@@ -20,8 +20,43 @@ describe('scraping', function() {
 
 	var url;
 
+	describe('Resolve parseAll promises for partial metadata', function() {
+		it('should resolve promise from woorank', function() {
+			url = 'http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/';
+			return assert.ok(meta(url));
+		});
+
+		it('should resolve promise from blog.schema.org', function() {
+			url = 'http://blog.schema.org';
+			return assert.ok(meta(url));
+		});
+	});
+
+	it('should get BE Press metadata tags', function() {
+		url = 'http://biostats.bepress.com/harvardbiostat/paper154/';
+		return preq.get(url).then(function(callRes) {
+			var expectedAuthors = ['Claggett, Brian', 'Xie, Minge', 'Tian, Lu'];
+			var expectedAuthorInstitutions = ['Harvard', 'Rutgers University - New Brunswick/Piscataway', 'Stanford University School of Medicine'];
+			var chtml = cheerio.load(callRes.body);
+
+			return meta.parseBEPress(chtml)
+			.then(function(results) {
+				var authors = results.author;
+				var authorInstitutions = results.author_institution;
+				assert.deepEqual(authors, expectedAuthors);
+				assert.deepEqual(authorInstitutions, expectedAuthorInstitutions);
+				['series_title', 'author', 'author_institution', 'title', 'date', 'pdf_url',
+				 'abstract_html_url', 'publisher', 'online_date'].forEach(function(key) {
+					if(!results[key]) {
+						throw new Error('Expected to find the ' + key + ' key in the response!');
+					}
+				});
+			});
+		});
+	});
+
 	it('should get COinS metadata', function() {
-		var url = 'https://en.wikipedia.org/wiki/Viral_phylodynamics';
+		url = 'https://en.wikipedia.org/wiki/Viral_phylodynamics';
 		return preq.get(url).then(function(callRes) {
 			var chtml = cheerio.load(callRes.body);
 			return meta.parseCOinS(chtml)
@@ -33,60 +68,17 @@ describe('scraping', function() {
 		});
 	});
 
-	it('should get OpenGraph info', function() {
-		var url = 'http://fortune.com/2015/02/20/nobel-prize-economics-for-sale/';
-		return meta(url)
-		.catch(function(e){throw e;})
-		.then(function(res) {
-			['title', 'description', 'author'].forEach(function(key) {
-				if(!res.openGraph[key]) {
-					throw new Error('Expected to find the ' + key + ' key in the response!');
-				}
-			});
-		});
-	});
-
-	it('should get OpenGraph image tag urls and metadata correctly', function() {
-		url = 'https://github.com';
-		return meta(url)
-		.catch(function(e){throw e;})
-		.then(function(res) {
-			var expectedImage = '{"url":"https://assets-cdn.github.com/images/modules/open_graph/github-logo.png","type":"image/png","width":"1200","height":"1200"},{"url":"https://assets-cdn.github.com/images/modules/open_graph/github-mark.png","type":"image/png","width":"1200","height":"620"},{"url":"https://assets-cdn.github.com/images/modules/open_graph/github-octocat.png","type":"image/png","width":"1200","height":"620"}';
-			assert.deepEqual(JSON.stringify(res.openGraph.image), expectedImage);
-		});
-	});
-
-	it('should resolve promise', function() {
-		url = 'http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/';
-		return assert.ok(meta(url));
-	});
-
-	it('should resolve promise', function() {
-		url = 'http://blog.schema.org';
-		return assert.ok(meta(url));
-	});
-
-	it('should get schema.org microdata', function() {
-		var url = 'http://blog.schema.org/';
-		return preq.get(url).then(function(callRes) {
-			var expected = '{"items":[{"type":["http://schema.org/Blog"],"properties":{"name":["schema blog"]}}]}';
-			var chtml = cheerio.load(callRes.body);
-			return meta.parseSchemaOrgMicrodata(chtml)
-			.then(function(results){
-				assert.deepEqual(JSON.stringify(results), expected);
-			});
-		});
-	});
-
-	it('should get basic BE Press metadata', function() {
-		url = 'http://biostats.bepress.com/harvardbiostat/paper154/';
+	it('should get EPrints metadata', function() {
+		url = 'http://eprints.gla.ac.uk/113711/';
 		return preq.get(url).then(function(callRes) {
 			var chtml = cheerio.load(callRes.body);
+			var expectedAuthors = ['Gatherer, Derek', 'Kohl, Alain'];
 
-			return meta.parseBEPress(chtml)
+			return meta.parseEprints(chtml)
 			.then(function(results) {
-				['series_title', 'author', 'author_institution', 'title', 'date', 'pdf_url',
-				 'abstract_html_url', 'publisher', 'online_date'].forEach(function(key) {
+				assert.deepEqual(results.creators_name, expectedAuthors); // Compare authors values
+				// Ensure all keys are in response
+				['eprintid', 'datestamp', 'title', 'abstract', 'issn', 'creators_name', 'publication', 'citation'].forEach(function(key) {
 					if(!results[key]) {
 						throw new Error('Expected to find the ' + key + ' key in the response!');
 					}
@@ -95,30 +87,16 @@ describe('scraping', function() {
 		});
 	});
 
-	it('should get BE Press author and author_institution tags correctly', function() {
-		url = 'http://biostats.bepress.com/harvardbiostat/paper154/';
-		return preq.get(url).then(function(callRes) {
-			var expectedAuthors = '["Claggett, Brian", "Xie, Minge", "Tian, Lu"]';
-			var expectedAuthorInstitutions = '["Harvard", "Rutgers University - New Brunswick/Piscataway", "Stanford University School of Medicine"]';
-			var chtml = cheerio.load(callRes.body);
-
-			return meta.parseBEPress(chtml)
-			.then(function(results) {
-				var authors = results.author;
-				var authorInstitutions = results.author_institution;
-				assert.deepEqual(JSON.stringify(authors), expectedAuthors);
-				assert.deepEqual(JSON.stringify(authorInstitutions), expectedAuthorInstitutions);
-			});
-		});
-	});
-
-	it('should get basic Highwire Press metadata', function() {
+	it('should get Highwire Press metadata', function() {
 		url = 'http://mic.microbiologyresearch.org/content/journal/micro/10.1099/mic.0.26954-0';
 		return preq.get(url).then(function(callRes) {
 			var chtml = cheerio.load(callRes.body);
+			var expectedAuthors = ['Jacqueline M. Reimers', 'Karen H. Schmidt', 'Angelika Longacre', 'Dennis K. Reschke', 'Barbara E. Wright'];
 
 			return meta.parseHighwirePress(chtml)
 			.then(function(results) {
+				assert.deepEqual(results.author, expectedAuthors); // Compare authors values
+				// Ensure all keys are in response
 				['journal_title', 'issn', 'doi', 'publication_date', 'title', 'author', 'author_institution',
 				 'volume', 'issue', 'firstpage', 'lastpage', 'publisher', 'abstract', 'reference'].forEach(function(key) {
 					if(!results[key]) {
@@ -129,38 +107,41 @@ describe('scraping', function() {
 		});
 	});
 
-	it('should get Highwire Press author tags correctly', function() {
-		url = 'http://mic.microbiologyresearch.org/content/journal/micro/10.1099/mic.0.26954-0';
-		return preq.get(url).then(function(callRes) {
-			var expectedAuthors = '["Jacqueline Reimers", "Karen H. Schmidt", "Angelika Longacre", "Dennis K. Reschke", "Barbara E. Wright"]';
-			var chtml = cheerio.load(callRes.body);
-
-			return meta.parseHighwirePress(chtml)
-			.then(function(results) {
-				var authors = results.authors;
-				assert.deepEqual(JSON.stringify(authors), expectedAuthors);
-			});
-		});
-	});
-
-	it('should get basic EPrints metadata and check for author tags', function() {
-		url = 'http://eprints.gla.ac.uk/113711/';
-		return preq.get(url).then(function(callRes) {
-			var chtml = cheerio.load(callRes.body);
-
-			return meta.parseEprints(chtml)
-			.then(function(results) {
-				['eprintid', 'datestamp', 'title', 'abstract', 'issn', 'creators_name', 'publication', 'citation'].forEach(function(key) {
-					if(!results[key]) {
+ 	describe('openGraph tests', function() {
+		it('should get OpenGraph info', function() {
+			url = 'http://fortune.com/2015/02/20/nobel-prize-economics-for-sale/';
+			return meta(url)
+			.catch(function(e){throw e;})
+			.then(function(res) {
+				['title', 'description', 'author'].forEach(function(key) {
+					if(!res.openGraph[key]) {
 						throw new Error('Expected to find the ' + key + ' key in the response!');
 					}
 				});
-				var authors = results.creators_name;
-				var expectedAuthors = '["Gatherer, Derek", "Kohl, Alain"]';
-				assert.deepEqual(JSON.stringify(authors), expectedAuthors);
+			});
+		});
+
+		it('should get OpenGraph image tag urls and metadata correctly', function() {
+			url = 'https://github.com';
+			return meta(url)
+			.catch(function(e){throw e;})
+			.then(function(res) {
+				var expectedImage = '{"url":"https://assets-cdn.github.com/images/modules/open_graph/github-logo.png","type":"image/png","width":"1200","height":"1200"},{"url":"https://assets-cdn.github.com/images/modules/open_graph/github-mark.png","type":"image/png","width":"1200","height":"620"},{"url":"https://assets-cdn.github.com/images/modules/open_graph/github-octocat.png","type":"image/png","width":"1200","height":"620"}';
+				assert.deepEqual(JSON.stringify(res.openGraph.image), expectedImage);
 			});
 		});
 	});
 
+	it('should get Schema.org Microdata', function() {
+		url = 'http://blog.schema.org/';
+		return preq.get(url).then(function(callRes) {
+			var expected = '{"items":[{"type":["http://schema.org/Blog"],"properties":{"name":["schema blog"]}}]}';
+			var chtml = cheerio.load(callRes.body);
+			return meta.parseSchemaOrgMicrodata(chtml)
+			.then(function(results){
+				assert.deepEqual(JSON.stringify(results), expected);
+			});
+		});
+	});
 
 });


### PR DESCRIPTION
* Eliminate duplicate requests for the same
resource
* Use direct object comparison instead of
stringify comparison (fixes erroneously passing
test.)
* Other minor fixes