### PR TITLE
Bump preq to v0.5.2 and release v1.6.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,6 @@
 
 var BBPromise = require('bluebird');
 var cheerio = require('cheerio');
-var preq = require('preq'); // Promisified Request library
 var microdata = require('microdata-node'); // Schema.org microdata
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "html-metadata",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Scrapes metadata of several different standards",
   "main": "index.js",
   "dependencies": {
     "bluebird": "3.4.6",
     "cheerio": "0.22.0",
     "microdata-node": "0.2.1",
-    "preq": "0.5.1"
+    "preq": "0.5.2"
   },
   "devDependencies": {
     "istanbul": "0.4.5",


### PR DESCRIPTION
preq v0.5.1 contained a subtle bug where the client had to provide the `uri` property instead of `url`. The new version fixes that.