### PR TITLE
Exposed loadHTML method

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,18 @@ exports.parseAll = function(chtml, callback){
 };
 
 /**
+ * Exported function that takes html string and
+ * returns a BBPromise for all available metadata
+ *
+ * @param  {Object}   html  	 html String HTML of the page
+ * @param  {Function} [callback] Optional callback
+ * @return {Object}              BBPromise for metadata
+ */
+exports.loadHTML = function(html, callback) {
+	return index.parseAll(cheerio.load(html)).nodeify(callback);
+};
+
+/**
  * Scrapes BE Press metadata given html object
  *
  * @param  {Object}   chtml      html Cheerio object

--- a/index.js
+++ b/index.js
@@ -34,30 +34,6 @@ exports = module.exports = function(urlOrOpts, callback) {
 };
 
 /**
- * Returns Object containing all available datatypes, keyed
- * using the same keys as in metadataFunctions.
- *
- * @param  {Object}   chtml      html Cheerio object to parse
- * @param  {Function} [callback] optional callback function
- * @return {Object}              BBPromise for metadata
- */
-exports.parseAll = function(chtml, callback){
-	return index.parseAll(chtml).nodeify(callback);
-};
-
-/**
- * Exported function that takes html string and
- * returns a BBPromise for all available metadata
- *
- * @param  {String}   html  	 html String HTML of the page
- * @param  {Function} [callback] Optional callback
- * @return {Object}              BBPromise for metadata
- */
-exports.loadFromString = function(html, callback) {
-	return index.parseAll(cheerio.load(html)).nodeify(callback);
-};
-
-/**
  * Exported function that takes html file and
  * returns a BBPromise for all available metadata
  *
@@ -78,6 +54,30 @@ exports.loadFromFile = function(path, opts, callback) {
 	return fs.readFileAsync(path, opts).then(html =>
 		index.parseAll(cheerio.load(html)).nodeify(callback)
 	);
+};
+
+/**
+ * Exported function that takes html string and
+ * returns a BBPromise for all available metadata
+ *
+ * @param  {String}   html  	 html String HTML of the page
+ * @param  {Function} [callback] Optional callback
+ * @return {Object}              BBPromise for metadata
+ */
+exports.loadFromString = function(html, callback) {
+	return index.parseAll(cheerio.load(html)).nodeify(callback);
+};
+
+/**
+ * Returns Object containing all available datatypes, keyed
+ * using the same keys as in metadataFunctions.
+ *
+ * @param  {Object}   chtml      html Cheerio object to parse
+ * @param  {Function} [callback] optional callback function
+ * @return {Object}              BBPromise for metadata
+ */
+exports.parseAll = function(chtml, callback){
+	return index.parseAll(chtml).nodeify(callback);
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ Import modules
 var BBPromise = require('bluebird');
 var cheerio = require('cheerio');
 var preq = require('preq'); // Promisified Request library
+var fs = require('fs');
 
 var index = require('./lib/index.js');
 
@@ -48,11 +49,24 @@ exports.parseAll = function(chtml, callback){
  * Exported function that takes html string and
  * returns a BBPromise for all available metadata
  *
- * @param  {Object}   html  	 html String HTML of the page
+ * @param  {String}   html  	 html String HTML of the page
  * @param  {Function} [callback] Optional callback
  * @return {Object}              BBPromise for metadata
  */
-exports.loadHTML = function(html, callback) {
+exports.loadFromString = function(html, callback) {
+	return index.parseAll(cheerio.load(html)).nodeify(callback);
+};
+
+/**
+ * Exported function that takes html file and
+ * returns a BBPromise for all available metadata
+ *
+ * @param  {String}   path  	 path Path to HTML file
+ * @param  {Function} [callback] Optional callback
+ * @return {Object}              BBPromise for metadata
+ */
+exports.loadFromFile = function(path, callback) {
+	var html = fs.readFileSync(path, 'utf-8');
 	return index.parseAll(cheerio.load(html)).nodeify(callback);
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -280,7 +280,6 @@ exports.parseEprints = BBPromise.method(function(chtml){
  * @return {Object}         BBPromise for general metadata
  */
 exports.parseGeneral = BBPromise.method(function(chtml){
-
 	var clutteredMeta = {
 		author: chtml('meta[name=author i]').first().attr('content'), //author <meta name="author" content="">
 		authorlink: chtml('link[rel=author i]').first().attr('href'), //author link <link rel="author" href="">
@@ -290,7 +289,7 @@ exports.parseGeneral = BBPromise.method(function(chtml){
 		robots: chtml('meta[name=robots i]').first().attr('content'), //robots <meta name ="robots" content="">
 		shortlink: chtml('link[rel=shortlink i]').first().attr('href'), //short link <link rel="shortlink" href="">
 		title: chtml('title').first().text(), //title tag <title>
-		lang: chtml('html').first().attr('lang') //lang <html lang="">
+		lang: chtml('html').first().attr('lang') || chtml('html').first().attr('xml:lang') //lang <html lang=""> or <html xml:lang="">
 	};
 
 	// Copy key-value pairs with defined values to meta

--- a/test/scraping.js
+++ b/test/scraping.js
@@ -203,14 +203,14 @@ describe('scraping', function() {
 			return meta(url)
 			.catch(function(e){throw e;})
 			.then(function(res) {
-				var expected = '{"app":{"id":{"iphone":"409128287","ipad":"409128287","googleplay":"com.guardian"},"name":{"googleplay":"The Guardian","ipad":"The Guardian","iphone":"The Guardian"},"url":{"ipad":"gnmguardian://us?contenttype=front&source=twitter","iphone":"gnmguardian://us?contenttype=front&source=twitter"}},"site":"@guardian","card":"summary","url":"https://www.theguardian.com/us"}';
+				var expected = '{"app":{"id":{"iphone":"409128287","ipad":"409128287","googleplay":"com.guardian"},"name":{"googleplay":"The Guardian","ipad":"The Guardian","iphone":"The Guardian"},"url":{"ipad":"gnmguardian://us?contenttype=front&source=twitter","iphone":"gnmguardian://us?contenttype=front&source=twitter"}},"site":"@guardian","card":"summary","dnt":"on","url":"https://www.theguardian.com/us"}';
 				assert.deepEqual(JSON.stringify(res.twitter), expected);
 			});
 		});
 	});
 
 	describe('parseJsonLd function', function() {
-		var urls = ['http://www.theguardian.com/us', 'http://jsonld.com/', 'http://www.apple.com/'];
+		var urls = ['http://www.theguardian.com/us', 'http://www.apple.com/'];
 		urls.forEach(function(test) {
 			describe(test, function() {
 				it('should return an object or array and get correct data', function() {

--- a/test/static.js
+++ b/test/static.js
@@ -38,6 +38,24 @@ describe('static files', function() {
 			assert.deepEqual(results, expected);
 		});
 	});
+	it('should get correct info using loadFromFile method using encoding from turtle movie file ', function() {
+		expected = JSON.parse(fs.readFileSync('./test/static/turtle_movie.json'));
+		return meta.loadFromFile('./test/static/turtle_movie.html', { encoding: 'utf-8' }).then(function(results){
+			assert.deepEqual(results, expected);
+		});
+	});
+	it('should get correct info using loadFromFile method using encoding and callback from turtle movie file ', function() {
+		expected = JSON.parse(fs.readFileSync('./test/static/turtle_movie.json'));
+		return meta.loadFromFile('./test/static/turtle_movie.html', { encoding: 'utf-8' }, (err, results) => {
+			assert.deepEqual(results, expected);
+		});
+	});
+	it('should get correct info using loadFromFile method using only callback from turtle movie file ', function() {
+		expected = JSON.parse(fs.readFileSync('./test/static/turtle_movie.json'));
+		return meta.loadFromFile('./test/static/turtle_movie.html', (err, results) => {
+			assert.deepEqual(results, expected);
+		});
+	});
 
 	it('should get correct info from turtle article file', function() {
 		expected = JSON.parse(fs.readFileSync('./test/static/turtle_article.json'));

--- a/test/static.js
+++ b/test/static.js
@@ -24,6 +24,21 @@ describe('static files', function() {
 		});
 	});
 
+	it('should get correct info using loadFromString method from turtle movie file ', function() {
+		expected = JSON.parse(fs.readFileSync('./test/static/turtle_movie.json'));
+		var html = fs.readFileSync('./test/static/turtle_movie.html');
+		return meta.loadFromString(html).then(function(results){
+			assert.deepEqual(results, expected);
+		});
+	});
+
+	it('should get correct info using loadFromFile method from turtle movie file ', function() {
+		expected = JSON.parse(fs.readFileSync('./test/static/turtle_movie.json'));
+		return meta.loadFromFile('./test/static/turtle_movie.html').then(function(results){
+			assert.deepEqual(results, expected);
+		});
+	});
+
 	it('should get correct info from turtle article file', function() {
 		expected = JSON.parse(fs.readFileSync('./test/static/turtle_article.json'));
 		$ = cheerio.load(fs.readFileSync('./test/static/turtle_article.html'));


### PR DESCRIPTION
In my use case I've already downloaded the HTML files and needed to parse them locally.

So I exposed a function `loadHTML` that takes the html as string and then internally converts it into cheerio object.

Here is usage example: 
```
const html = fs.readFileSync('./page.html', 'utf-8');
scrape.loadHTML(html).then(function(metadata){
	console.log(JSON.stringify(metadata, null, 4));
});
```