### PR TITLE
Fix failing tests due to upstream changes

### DIFF
--- a/test/scraping.js
+++ b/test/scraping.js
@@ -95,10 +95,10 @@ describe('scraping', function() {
 	});
 
 	describe('parseGeneral function', function() {
-		it('should get hu parameter', function() {
-			var expected = "hu";
+		it('should get html lang parameter', function() {
+			var expected = "fr";
 			var options =  {
-    		url: "http://mno.hu/migr_1834/tellerlevel-cafolat-es-cafolat-700280",
+    		url: "http://www.lemonde.fr",
     		headers: {
         	'User-Agent': 'webscraper'
     			}
@@ -142,7 +142,7 @@ describe('scraping', function() {
 				return meta.parseOpenGraph(chtml)
 				.catch(function(e){throw e;})
 				.then(function(res) {
-					['title', 'description', 'author'].forEach(function(key) {
+					['title', 'description'].forEach(function(key) {
 						if(!res.hasOwnProperty(key)) {
 							throw new Error('Expected to find the ' + key + ' key in the response!');
 						}
@@ -203,14 +203,14 @@ describe('scraping', function() {
 			return meta(url)
 			.catch(function(e){throw e;})
 			.then(function(res) {
-				var expected = '{"app":{"id":{"iphone":"409128287","ipad":"409128287","googleplay":"com.guardian"},"name":{"googleplay":"The Guardian","ipad":"The Guardian","iphone":"The Guardian"},"url":{"ipad":"gnmguardian://us?contenttype=front&source=twitter","iphone":"gnmguardian://us?contenttype=front&source=twitter"}},"site":"@guardian","card":"summary","url":"https://www.theguardian.com/us"}';
+				var expected = '{"app":{"id":{"iphone":"409128287","ipad":"409128287","googleplay":"com.guardian"},"name":{"googleplay":"The Guardian","ipad":"The Guardian","iphone":"The Guardian"},"url":{"ipad":"gnmguardian://us?contenttype=front&source=twitter","iphone":"gnmguardian://us?contenttype=front&source=twitter"}},"site":"@guardian","card":"summary","dnt":"on","url":"https://www.theguardian.com/us"}';
 				assert.deepEqual(JSON.stringify(res.twitter), expected);
 			});
 		});
 	});
 
 	describe('parseJsonLd function', function() {
-		var urls = ['http://www.theguardian.com/us', 'http://jsonld.com/', 'http://www.apple.com/'];
+		var urls = ['http://www.theguardian.com/us', 'http://www.apple.com/'];
 		urls.forEach(function(test) {
 			describe(test, function() {
 				it('should return an object or array and get correct data', function() {


### PR DESCRIPTION
* Change language scraping test to lemonde.fr
as the hu site now uses xml:lang instead of
lang. TODO: investigate xml:lang.
* Apparently jsonld.com stopped actually
having and jsonld in their page (???) so
remove that site from being checked.
* Fortune.com no longer provides the author
in their open graph metadata :/
* Afposten added an additional field to
their Twitter metadata