### PR TITLE
Updates packages, fix tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -383,9 +383,9 @@ exports.parseJsonLd = BBPromise.method(function(chtml) {
 	var jsonLd = chtml('script[type="application/ld+json"]');
 
 	jsonLd.each(function() {
-		var contents = chtml(this).text().trim();
+		var contents;
 		try {
-			contents = JSON.parse(contents);
+			contents = JSON.parse(this.children[0].data);
 		} catch (e) {
 			// Fail silently, just in case there are valid tags
 			return;

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "Scrapes metadata of several different standards",
   "main": "index.js",
   "dependencies": {
-    "bluebird": "3.4.6",
-    "cheerio": "0.22.0",
+    "bluebird": "3.5.1",
+    "cheerio": "1.0.0-rc.2",
     "microdata-node": "0.2.1",
-    "preq": "0.5.2"
+    "preq": "0.5.4"
   },
   "devDependencies": {
     "istanbul": "0.4.5",
-    "mocha": "3.2.0",
+    "mocha": "4.0.1",
     "mocha-jshint": "2.3.1",
-    "mocha-lcov-reporter": "1.2.0"
+    "mocha-lcov-reporter": "1.3.0"
   },
   "scripts": {
     "test": "mocha",
@@ -29,6 +29,7 @@
     "open graph",
     "metadata",
     "microdata",
+    "prism",
     "twitter cards",
     "web scraper"
   ],

--- a/test/errors.js
+++ b/test/errors.js
@@ -109,13 +109,11 @@ describe('errors', function() {
 		});
 	});
 
-	it('should reject promise with malformed JSON-LD and missing content tags', function() {
+	it('should reject parseALL promise for entire error file', function() {
 		var $ = cheerio.load(fs.readFileSync('./test/static/turtle_article_errors.html'));
 		return assert.fails(meta.parseAll($));
 	});
 
-	//TODO: Add test for lacking general metadata
-	//TODO: Add test for lacking any metadata
 
 	it('should reject promise with undefined cheerio object', function() {
 		var prom = meta.parseOpenGraph(undefined);

--- a/test/scraping.js
+++ b/test/scraping.js
@@ -34,7 +34,7 @@ describe('scraping', function() {
 	});
 
 	describe('parseBEPress function', function() {
-		it.skip('should get BE Press metadata tags', function() {
+		it('should get BE Press metadata tags', function() {
 			url = 'http://biostats.bepress.com/harvardbiostat/paper154/';
 			return preq.get(url).then(function(callRes) {
 				var expectedAuthors = ['Claggett, Brian', 'Xie, Minge', 'Tian, Lu'];
@@ -74,7 +74,7 @@ describe('scraping', function() {
 	});
 
 	describe('parseEPrints function', function() {
-		it.skip('should get EPrints metadata', function() {
+		it('should get EPrints metadata', function() {
 			url = 'http://eprints.gla.ac.uk/113711/';
 			return preq.get(url).then(function(callRes) {
 				var chtml = cheerio.load(callRes.body);


### PR DESCRIPTION
* Update packages (preq, bluebird, mocha, cheerio)
* Fix name of test to be more descriptive
* Restore two tests that were previously failing due to website being
down
* Minor fix for cheerio update in jsonLd due to non-backwards
compatible changes