### PR TITLE
Fetch the direction metadata from <html> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The method parseGeneral obtains the following general metadata:
 <link rel="shortlink" href="">
 <title></title>
 <html lang="en">
+<html dir="rtl">
 ```
 
 ## Tests

--- a/lib/index.js
+++ b/lib/index.js
@@ -302,7 +302,8 @@ exports.parseGeneral = BBPromise.method(function(chtml){
 		robots: chtml('meta[name=robots i]').first().attr('content'), //robots <meta name ="robots" content="">
 		shortlink: chtml('link[rel=shortlink i]').first().attr('href'), //short link <link rel="shortlink" href="">
 		title: chtml('title').first().text(), //title tag <title>
-		lang: chtml('html').first().attr('lang') || chtml('html').first().attr('xml:lang') //lang <html lang=""> or <html xml:lang="">
+		lang: chtml('html').first().attr('lang') || chtml('html').first().attr('xml:lang'), //lang <html lang=""> or <html xml:lang="">
+		dir: chtml('html').first().attr('dir') //dir <html dir="">
 	};
 
 	// Copy key-value pairs with defined values to meta

--- a/test/scraping.js
+++ b/test/scraping.js
@@ -101,12 +101,28 @@ describe('scraping', function() {
 				url: "http://www.lemonde.fr",
 				headers: {
 					'User-Agent': 'webscraper'
-					}
+				}
 			};
 			return preq.get(options).then(function(callRes) {
 				var chtml = cheerio.load(callRes.body);
 				return meta.parseGeneral(chtml).then(function(results) {
 					assert.deepEqual(results.lang, expected);
+				});
+			});
+		});
+
+		it('should get html dir parameter', function() {
+			var expected = "rtl";
+			var options =  {
+				url: "https://www.iranrights.org/fa/",
+				headers: {
+					'User-Agent': 'webscraper'
+				}
+			};
+			return preq.get(options).then(function(callRes) {
+				var chtml = cheerio.load(callRes.body);
+				return meta.parseGeneral(chtml).then(function(results) {
+					assert.deepEqual(results.dir, expected);
 				});
 			});
 		});

--- a/test/static.js
+++ b/test/static.js
@@ -65,7 +65,7 @@ describe('static files', function() {
 		});
 	});
 
-	it('should be case insensitive on Turtle Article file', function() {
+	it('should be case insensitive on turtle article file', function() {
 		expected = JSON.parse(fs.readFileSync('./test/static/turtle_article.json'));
 		$ = cheerio.load(fs.readFileSync('./test/static/turtle_article_case.html'));
 		return meta.parseAll($).then(function(results){

--- a/test/static/turtle_article.html
+++ b/test/static/turtle_article.html
@@ -1,4 +1,4 @@
-<html lang="en">
+<html lang="en" dir="ltr">
 
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 

--- a/test/static/turtle_article.json
+++ b/test/static/turtle_article.json
@@ -50,6 +50,7 @@
 		"authorlink": "http://examples.com/turtlelvr",
 		"canonical": "http://example.com/turtles",
 		"description": "Exposition on the awesomeness of turtles",
+		"dir": "ltr",
 		"icons": [
 			{
 				"href": "turtle.png",

--- a/test/static/turtle_article_case.html
+++ b/test/static/turtle_article_case.html
@@ -1,4 +1,4 @@
-<html lang="en">
+<html lang="en" dir="ltr">
 <!--
 Turtle Article containing capitALised tags to test case sensitivity
 -->


### PR DESCRIPTION
This fetches the `dir` (e.g. "rtl") attribute from the `<html>` tag.