### PR TITLE
Update Readme to include badge and link to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 html-metadata
 =============
-
-# MetaData html scraper and parser for Node.js (supports Promises and callback style)
+[![npm](https://img.shields.io/npm/v/html-metadata.svg)](https://www.npmjs.com/package/html-metadata)
+> MetaData html scraper and parser for Node.js (supports Promises and callback style)
 
 The aim of this library is to be a comprehensive source for extracting all html embedded metadata. Currently it supports Schema.org microdata using a third party library, a native BEPress, Dublin Core, Highwire Press, JSON-LD, Open Graph, Twitter, EPrints, PRISM, and COinS implementation, and some general metadata that doesn't belong to a particular standard (for instance, the content of the title tag, or meta description tags).
 
@@ -9,7 +9,7 @@ Planned is support for RDFa, AGLS, and other yet unheard of metadata types. Cont
 
 ## Install
 
-	npm install git://github.com/wikimedia/html-metadata.git
+	npm install html-metadata
 
 ## Usage
 


### PR DESCRIPTION
This includes the badge and package name- the typical user would likely want the npm package vs. a direct install from github. 