### PR TITLE
Update and pin cheerio version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "html-metadata",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "html-metadata",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"bluebird": "^3.7.1",
-				"cheerio": "^1.0.0-rc.10",
+				"cheerio": "1.0.0-rc.12",
 				"microdata-node": "^0.2.1",
 				"preq": "^0.5.12"
 			},

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "html-metadata",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Scrapes metadata of several different standards",
 	"main": "index.js",
 	"dependencies": {
 		"bluebird": "^3.7.1",
-		"cheerio": "^1.0.0-rc.10",
+		"cheerio": "1.0.0-rc.12",
 		"microdata-node": "^0.2.1",
 		"preq": "^0.5.12"
 	},


### PR DESCRIPTION
Pin cheerio to 1.0.0-rc.12 as 1.0.0 requires node >= 18