### PR TITLE
[CI] Remove support for node <18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "nock": "^13.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/abbrev": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "coverage": "istanbul cover _mocha -- -R spec"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "keywords": [
     "bepress",


### PR DESCRIPTION
Require node >= 18, in preparation
for removing the deprecated preq library
and replacing it with native fetch, released
in node 18.

Remove testing for node >= and add testing
for node 20 and 22.

Also make CI run on main branch as it was renamed
from master. 

Bug: T361602