### PR TITLE
Remove support for node <18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"nock": "^13.3.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"coverage": "istanbul cover _mocha -- -R spec"
 	},
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"keywords": [
 		"bepress",


### PR DESCRIPTION
Require node >= 18, in preparation
for removing the deprecated preq library
and replacing it with native fetch, released
in node 18.

Remove testing for node >= and add testing
for node 20 and 22.

Rename master branch to main in ci as this
is now the default branch name.

Bug: T361602