### PR TITLE
[BREAKING CHANGE] Remove support for callback (node-style) requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 html-metadata
 =============
 [![npm](https://img.shields.io/npm/v/html-metadata.svg)](https://www.npmjs.com/package/html-metadata)
-> MetaData html scraper and parser for Node.js (supports Promises and callback style)
+> MetaData html scraper and parser for Node.js (supports Promises only. Callbacks were deprecated in 3.0.0)
 
 The aim of this library is to be a comprehensive source for extracting all html embedded metadata. Currently it supports Schema.org microdata using a third party library, a native BEPress, Dublin Core, Highwire Press, JSON-LD, Open Graph, Twitter, EPrints, PRISM, and COinS implementation, and some general metadata that doesn't belong to a particular standard (for instance, the content of the title tag, or meta description tags).
 
@@ -13,8 +13,6 @@ Planned is support for RDFa, AGLS, and other yet unheard of metadata types. Cont
 
 ## Usage
 
-Promise-based:
-
 ```js
 var scrape = require('html-metadata');
 
@@ -25,21 +23,8 @@ scrape(url).then(function(metadata){
 });
 ```
 
-Callback-based:
-
-```js
-var scrape = require('html-metadata');
-
-var url = "http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/";
-
-scrape(url, function(error, metadata){
-	console.log(metadata);
-});
-```
-
 The scrape method used here invokes the parseAll() method, which uses all the available methods registered in method metadataFunctions(), and are available for use separately as well, for example:
 
-Promise-based:
 ```js
 var cheerio = require('cheerio');
 var parseDublinCore = require('html-metadata').parseDublinCore;
@@ -54,33 +39,15 @@ fetch(url).then(function(response){
 });
 ```
 
-Callback-based:
-```js
-var cheerio = require('cheerio');
-var request = require('request');
-var parseDublinCore = require('html-metadata').parseDublinCore;
+Options dictionary:
 
-var url = "http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/";
-
-request(url, function(error, response, html){
-	$ = cheerio.load(html);
-	parseDublinCore($, function(error, metadata){
-		console.log(metadata);
-	});
-});
-```
-
-Options object:
-
-You can also pass an [options object](https://github.com/request/request#requestoptions-callback) as the first argument containing extra parameters. Some websites require the user-agent or cookies to be set in order to get the response.
+You can also pass an [options dictionary](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit) as the first argument containing extra parameters. Some websites require the user-agent or cookies to be set in order to get the response. This is identifical to the RequestInit dictionary except that it should also contain the requested url as part of the dictionary. 
 
 ```
 var scrape = require('html-metadata');
-var request = require('request');
 
 var options =  {
-	url: "http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/",
-	jar: request.jar(), // Cookie jar
+	url: "http://example.com",
 	headers: {
 		'User-Agent': 'webscraper'
 	}
@@ -116,5 +83,4 @@ The method parseGeneral obtains the following general metadata:
 
 ## Contributing
 
-Contributions welcome! All contibutions should use [bluebird promises](https://github.com/petkaantonov/bluebird) instead of callbacks,
-and be .nodeify()-ed in index.js so the functions can be used as either callbacks or Promises.
+Contributions welcome! All contibutions should use [bluebird promises](https://github.com/petkaantonov/bluebird) instead of callbacks.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * https://github.com/wikimedia/html-metadata
  *
  * This file wraps all exportable functions so that they
- * can be used either with Promises or with callbacks.
+ * can be used with Promises.
  */
 
 'use strict';
@@ -18,14 +18,13 @@ const index = require( './lib/index.js' );
 
 /**
  * Default exported function that takes a url string or
- * request library options object and returns a
+ * request library options dictionary and returns a
  * BBPromise for all available metadata
  *
- * @param  {Object}   urlOrOpts  url String or options Object
- * @param  {Function} [callback] Optional callback
+ * @param  {Object}   urlOrOpts  url String or options dictionary
  * @return {Object}              BBPromise for metadata
  */
-exports = module.exports = function ( urlOrOpts, callback ) {
+exports = module.exports = function ( urlOrOpts ) {
 	let url, opts;
 	if ( urlOrOpts instanceof Object ) {
 		if ( urlOrOpts.uri ) {
@@ -36,16 +35,15 @@ exports = module.exports = function ( urlOrOpts, callback ) {
 		url = urlOrOpts;
 	}
 	if ( !url ) {
-		return BBPromise.reject( 'No uri supplied in argument' ).nodeify( callback );
+		return BBPromise.reject( 'No uri supplied in argument' );
 	} else {
 		return BBPromise.resolve(
 			fetch( url, opts ).then( ( response ) => {
-				// todo check if either urloropts still works with fetch
 				return response.text().then( ( body ) => {
 					return index.parseAll( cheerio.load( body ) );
 				} );
 			} )
-		).nodeify( callback );
+		);
 	}
 };
 
@@ -55,33 +53,28 @@ exports = module.exports = function ( urlOrOpts, callback ) {
  *
  * @param  {string}   path       path Path to HTML file
  * @param  {Object}   [opts]     opts Additional options such as encoding
- * @param  {Function} [callback] Optional callback
  * @return {Object}              BBPromise for metadata
  */
-exports.loadFromFile = function ( path, opts, callback ) {
+exports.loadFromFile = function ( path, opts ) {
 	const defaultEncoding = 'utf-8';
 
 	opts = opts || defaultEncoding;
-	if ( typeof opts === 'function' ) {
-		callback = opts;
-		opts = defaultEncoding;
-	}
 
 	return fs.readFileAsync( path, opts ).then(
-		( html ) => index.parseAll( cheerio.load( html ) ).nodeify( callback )
+		( html ) => index.parseAll( cheerio.load( html ) )
 	);
 };
 
 /**
+ * c
  * Exported function that takes html string and
  * returns a BBPromise for all available metadata
  *
  * @param  {string}   html       html String HTML of the page
- * @param  {Function} [callback] Optional callback
  * @return {Object}              BBPromise for metadata
  */
-exports.loadFromString = function ( html, callback ) {
-	return index.parseAll( cheerio.load( html ) ).nodeify( callback );
+exports.loadFromString = function ( html ) {
+	return index.parseAll( cheerio.load( html ) );
 };
 
 /**
@@ -89,143 +82,130 @@ exports.loadFromString = function ( html, callback ) {
  * using the same keys as in metadataFunctions.
  *
  * @param  {Object}   chtml      html Cheerio object to parse
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseAll = function ( chtml, callback ) {
-	return index.parseAll( chtml ).nodeify( callback );
+exports.parseAll = function ( chtml ) {
+	return index.parseAll( chtml );
 };
 
 /**
  * Scrapes BE Press metadata given html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseBEPress = function ( chtml, callback ) {
-	return index.parseBEPress( chtml ).nodeify( callback );
+exports.parseBEPress = function ( chtml ) {
+	return index.parseBEPress( chtml );
 };
 
 /**
  * Scrapes embedded COinS data given Cheerio loaded html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseCOinS = function ( chtml, callback ) {
-	return index.parseCOinS( chtml ).nodeify( callback );
+exports.parseCOinS = function ( chtml ) {
+	return index.parseCOinS( chtml );
 };
 
 /**
  * Parses value of COinS title tag
  *
  * @param  {string}   title      String corresponding to value of title tag in span element
- * @param  {Function} [callback] Optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseCOinSTitle = function ( title, callback ) {
-	return index.parseCOinSTitle( title ).nodeify( callback );
+exports.parseCOinSTitle = function ( title ) {
+	return index.parseCOinSTitle( title );
 };
 
 /**
  * Scrapes Dublin Core data given Cheerio loaded html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseDublinCore = function ( chtml, callback ) {
-	return index.parseDublinCore( chtml ).nodeify( callback );
+exports.parseDublinCore = function ( chtml ) {
+	return index.parseDublinCore( chtml );
 };
 
 /**
  * Scrapes EPrints data given Cheerio loaded html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseEprints = function ( chtml, callback ) {
-	return index.parseEprints( chtml ).nodeify( callback );
+exports.parseEprints = function ( chtml ) {
+	return index.parseEprints( chtml );
 };
 
 /**
  * Scrapes general metadata terms given Cheerio loaded html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseGeneral = function ( chtml, callback ) {
-	return index.parseGeneral( chtml ).nodeify( callback );
+exports.parseGeneral = function ( chtml ) {
+	return index.parseGeneral( chtml );
 };
 
 /**
  * Scrapes Highwire Press metadata given html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseHighwirePress = function ( chtml, callback ) {
-	return index.parseHighwirePress( chtml ).nodeify( callback );
+exports.parseHighwirePress = function ( chtml ) {
+	return index.parseHighwirePress( chtml );
 };
 
 /**
  * Retrieves JSON-LD for given html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for JSON-LD
  */
-exports.parseJsonLd = function ( chtml, callback ) {
-	return index.parseJsonLd( chtml ).nodeify( callback );
+exports.parseJsonLd = function ( chtml ) {
+	return index.parseJsonLd( chtml );
 };
 
 /**
  * Scrapes OpenGraph data given html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseOpenGraph = function ( chtml, callback ) {
-	return index.parseOpenGraph( chtml ).nodeify( callback );
+exports.parseOpenGraph = function ( chtml ) {
+	return index.parseOpenGraph( chtml );
 };
 
 /**
  * Scrapes schema.org microdata given Cheerio loaded html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseSchemaOrgMicrodata = function ( chtml, callback ) {
-	return index.parseSchemaOrgMicrodata( chtml ).nodeify( callback );
+exports.parseSchemaOrgMicrodata = function ( chtml ) {
+	return index.parseSchemaOrgMicrodata( chtml );
 };
 
 /**
  * Scrapes Twitter data given html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parseTwitter = function ( chtml, callback ) {
-	return index.parseTwitter( chtml ).nodeify( callback );
+exports.parseTwitter = function ( chtml ) {
+	return index.parseTwitter( chtml );
 };
 
 /**
  * Scrapes PRISM data given html object
  *
  * @param  {Object}   chtml      html Cheerio object
- * @param  {Function} [callback] optional callback function
  * @return {Object}              BBPromise for metadata
  */
-exports.parsePrism = function ( chtml, callback ) {
-	return index.parsePrism( chtml ).nodeify( callback );
+exports.parsePrism = function ( chtml ) {
+	return index.parsePrism( chtml );
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "html-metadata",
-	"version": "2.0.1",
+	"version": "3.0.0",
 	"description": "Scrapes metadata of several different standards",
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION
Bluebird Promises provides support for nodeifying this library. However bluebird library use is now discouraged in favour of native Node Promises. In preparation for removing this library and switching to native JS Promises, remove support for callback style requests.

Increment package.json to 3.0.0 to go along with documentation, but not ready for release yet, as this release is planned to remove the bluebird library entirely.